### PR TITLE
Add geometric vector perceptrons (GVPs)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "1.0.0-DEV"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 GraphNeuralNetworks = "cffab07f-9bc2-4db1-8861-388f63bf7694"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Flux = "0.14"

--- a/src/MessagePassingIPA.jl
+++ b/src/MessagePassingIPA.jl
@@ -287,10 +287,10 @@ function (gvp::GeometricVectorPerceptron)(s::AbstractArray{T, 2}, V::AbstractArr
     s′, V′
 end
 
-# This makes chaining by Flux.Chain easier.
+# This makes chaining by Flux's Chain easier.
 (gvp::GeometricVectorPerceptron)((s, V)::Tuple{AbstractArray{T, 2}, AbstractArray{T, 3}}) where T  = gvp(s, V)
 
 # L2 norm along the first dimension
-norm1(X) = dropdims(sqrt.(sum(abs2.(X), dims = 1)), dims = 1)
+norm1(X) = dropdims(sqrt.(sum(abs2, X, dims = 1)), dims = 1)
 
 end

--- a/src/MessagePassingIPA.jl
+++ b/src/MessagePassingIPA.jl
@@ -293,12 +293,14 @@ end
 
 # Normalization for vector features
 struct VectorNorm
-    #eps::Float32
+    ϵ::Float32
 end
+
+VectorNorm(; eps::Real = 1f-5) = VectorNorm(eps)
 
 function (norm::VectorNorm)(V::AbstractArray{T, 3}) where T
     @assert size(V, 1) == 3
-    V ./ sqrt.(mean(sum(abs2, V, dims = 1), dims = 2))
+    V ./ (sqrt.(mean(sum(abs2, V, dims = 1), dims = 2)) .+ norm.ϵ)
 end
 
 # L2 norm along the first dimension

--- a/src/MessagePassingIPA.jl
+++ b/src/MessagePassingIPA.jl
@@ -243,6 +243,9 @@ function GeometricVectorPerceptron((sin, sout), (vin, vout), sσ::Function = ide
     GeometricVectorPerceptron(W_h, W_μ, scalar, vσ)
 end
 
+GeometricVectorPerceptron(sin::Integer, vin::Integer, σ::Function = identity; bias = true) =
+    GeometricVectorPerceptron(sin => sin, vin => vin, σ, σ; bias)
+
 function (gvp::GeometricVectorPerceptron)(s::AbstractArray, V::AbstractArray)
     V_h = batched_mul(V, gvp.W_h)
     s′ = gvp.scalar(cat(norm1(V_h), s, dims = 1))

--- a/src/MessagePassingIPA.jl
+++ b/src/MessagePassingIPA.jl
@@ -233,6 +233,8 @@ struct GeometricVectorPerceptron
     vσ
 end
 
+Flux.@functor GeometricVectorPerceptron
+
 function GeometricVectorPerceptron((sin, sout), (vin, vout), sσ::Function = identity, vσ::Function = identity; bias = true)
     h = max(vin, vout)  # intermediate dimension for vector mapping
     W_h = randn(Float32, vin, h)

--- a/src/MessagePassingIPA.jl
+++ b/src/MessagePassingIPA.jl
@@ -232,10 +232,10 @@ sumdrop(x; dims) = dropdims(sum(x; dims); dims)
 # ---------------------------
 
 struct GeometricVectorPerceptron
-    W_h
-    W_μ
+    W_h::AbstractMatrix
+    W_μ::AbstractMatrix
     scalar::Dense
-    vσ
+    vσ::Function
 end
 
 Flux.@functor GeometricVectorPerceptron

--- a/src/MessagePassingIPA.jl
+++ b/src/MessagePassingIPA.jl
@@ -265,7 +265,7 @@ the vector features are equivariant under any rotation and reflection.
 
 Jing, Bowen, et al. "Learning from protein structure with geometric vector perceptrons." arXiv preprint arXiv:2009.01411 (2020).
 """
-function GeometricVectorPerceptron((sin, sout), (vin, vout), sσ::Function = identity, vσ::Function = identity; bias = true)
+function GeometricVectorPerceptron((sin, sout), (vin, vout), sσ::Function = identity, vσ::Function = identity; bias::Bool = true)
     h = max(vin, vout)  # intermediate dimension for vector mapping
     W_h = randn(Float32, vin, h)
     W_μ = randn(Float32, h, vout)
@@ -273,7 +273,7 @@ function GeometricVectorPerceptron((sin, sout), (vin, vout), sσ::Function = ide
     GeometricVectorPerceptron(W_h, W_μ, scalar, vσ)
 end
 
-GeometricVectorPerceptron(sin::Integer, vin::Integer, σ::Function = identity; bias = true) =
+GeometricVectorPerceptron(sin::Integer, vin::Integer, σ::Function = identity; bias::Bool = true) =
     GeometricVectorPerceptron(sin => sin, vin => vin, σ, σ; bias)
 
 # s: scalar features (sin × batch)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -89,10 +89,14 @@ using Test
 
     @testset "VectorNorm" begin
         norm = VectorNorm()
-        V = randn(Float32, 3, 8, 128)
+        V = randn(Float32, 3, 5, 10)
         @test norm(V) isa Array{Float32, 3}
         @test size(norm(V)) == size(V)
         @test norm(V) ≈ norm(100 * V)
         @test all(sqrt.(mean(sum(abs2, norm(V), dims = 1), dims = 2)) .≈ 1)
+
+        # zero values
+        V = zeros(Float32, 3, 5, 10)
+        @test all(!isnan, norm(V))
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
-using MessagePassingIPA: RigidTransformation, InvariantPointAttention, transform, inverse_transform, compose, rigid_from_3points, GeometricVectorPerceptron
+using MessagePassingIPA: RigidTransformation, InvariantPointAttention, transform, inverse_transform, compose, rigid_from_3points, GeometricVectorPerceptron, VectorNorm
 using GraphNeuralNetworks: rand_graph
 using Flux: relu, batched_mul
 using Rotations: RotMatrix
+using Statistics: mean
 using Test
 
 @testset "MessagePassingIPA.jl" begin
@@ -70,8 +71,6 @@ using Test
 
         # check returned type and size
         s′, V′ = gvp(s, V)
-        @show typeof(s′)
-        @show typeof(V′)
         @test s′ isa Array{Float32, 2}
         @test V′ isa Array{Float32, 3}
         @test size(s′) == (sout, n)
@@ -86,5 +85,14 @@ using Test
         # utility constructor where #inputs == #outputs
         gvp = GeometricVectorPerceptron(12, 24, σ)
         @test gvp isa GeometricVectorPerceptron
+    end
+
+    @testset "VectorNorm" begin
+        norm = VectorNorm()
+        V = randn(Float32, 3, 8, 128)
+        @test norm(V) isa Array{Float32, 3}
+        @test size(norm(V)) == size(V)
+        @test norm(V) ≈ norm(100 * V)
+        @test all(sqrt.(mean(sum(abs2, norm(V), dims = 1), dims = 2)) .≈ 1)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,5 +82,9 @@ using Test
         s″, V″ = gvp(s, batched_mul(R, V))
         @test s″ ≈ s′
         @test V″ ≈ batched_mul(R, V′)
+
+        # utility constructor where #inputs == #outputs
+        gvp = GeometricVectorPerceptron(12, 24, σ)
+        @test gvp isa GeometricVectorPerceptron
     end
 end


### PR DESCRIPTION
An implementation example of a graph neural network using geometric vector perceptrons. Still need to check carefully.
```julia
using Flux
using GraphNeuralNetworks
using MessagePassingIPA: GeometricVectorPerceptron, VectorNorm
using Statistics: mean

struct GNN
    gvpstack::Chain
    sdropout::Dropout
    vdropout::Dropout
    snorm::LayerNorm
    vnorm::VectorNorm
end

Flux.@functor GNN

# s: scalar; v: vector
# n: node; e: edge
function GNN((sn, vn)::Tuple{Integer, Integer}, (se, ve)::Tuple{Integer, Integer}; dropout::Real = 0.1, σ::Function = relu)
    gvpstack = Chain(
        GeometricVectorPerceptron(sn + se => sn, vn + ve => vn, σ, σ),
        GeometricVectorPerceptron(sn => sn, vn => vn, σ, σ),
        GeometricVectorPerceptron(sn => sn, vn => vn),
    )
    sdropout = Dropout(dropout)
    vdropout = Dropout(dropout, dims = (2, 3))  # dropout whole vectors
    snorm = LayerNorm(sn)
    vnorm = VectorNorm()
    GNN(gvpstack, sdropout, vdropout, snorm, vnorm)
end

function (gnn::GNN)(g, (sn, vn), (se, ve))
    # run message passing
    function message(_, xj, e)
        s = cat(xj.s, e.s, dims = 1)
        v = cat(xj.v, e.v, dims = 2)
        gnn.gvpstack((s, v))
    end
    xj = (s = sn, v = vn)
    e = (s = se, v = ve)
    msgs = apply_edges(message, g; xj, e)
    s, v = aggregate_neighbors(g, mean, msgs)

    # update node embeddings
    sn = gnn.snorm(sn + gnn.sdropout(s))
    vn = gnn.vnorm(vn + gnn.vdropout(v))
    sn, vn
end

n = 10  # number of nodes
m = 8n  # number of edges
graph = rand_graph(n, m)
gnn = GNN((5, 8), (6, 9))
# (scalar embeddings, vector embeddings) for nodes and edges
node_embeddings = randn(Float32, 5, n), randn(Float32, 3, 8, n)
edge_embeddings = randn(Float32, 6, m), randn(Float32, 3, 9, m)

# update node embeddings
node_embeddings = gnn(graph, node_embeddings, edge_embeddings)

# check autodiff on GPU
using CUDA
gnn, graph, node_embeddings, edge_embeddings = gpu((gnn, graph, node_embeddings, edge_embeddings))
Flux.gradient(() -> sum(gnn(graph, node_embeddings, edge_embeddings)[1]), Flux.params(gnn))
```