### PR TITLE
Decompose QKV weight into separated weights

### DIFF
--- a/src/MessagePassingIPA.jl
+++ b/src/MessagePassingIPA.jl
@@ -1,9 +1,9 @@
 module MessagePassingIPA
 
-using Flux: Flux, Dense, flatten, unsqueeze, chunk, batched_mul, batched_vec, batched_transpose, softplus
+using Flux: Flux, Dense, flatten, unsqueeze, softplus
 using GraphNeuralNetworks: GNNGraph, apply_edges, softmax_edge_neighbors, aggregate_neighbors
 using LinearAlgebra: normalize
-using BatchedTransformations
+using BatchedTransformations: Translation, Rotation, Rigid, transform, inverse_transform
 
 # Algorithm 21 (x1: N, x2: Ca, x3: C)
 function rigid_from_3points(x1::AbstractVector, x2::AbstractVector, x3::AbstractVector)

--- a/src/MessagePassingIPA.jl
+++ b/src/MessagePassingIPA.jl
@@ -53,8 +53,8 @@ struct InvariantPointAttention
     n_point_values::Int
 
     # trainable layers and weights
-    map_nodes::Dense
-    map_points::Dense
+    map_nodes::NamedTuple
+    map_points::NamedTuple
     map_pairs::Dense
     map_final::Dense
     header_weights_raw::Any
@@ -83,11 +83,15 @@ function InvariantPointAttention(
     # initialize layer weights so that outputs have std = 1 (as assumed in
     # AlphaFold2) if inputs follow the standard normal distribution
     init = Flux.kaiming_uniform(gain=1.0)
-    map_nodes = Dense(n_dims_s => n_heads * c * 3, bias=false; init)
-    map_points = Dense(
-        n_dims_s => n_heads * (n_query_points * 2 + n_point_values) * 3,
-        bias=false;
-        init
+    map_nodes = (
+        q = Dense(n_dims_s => n_heads * c, bias=false; init),
+        k = Dense(n_dims_s => n_heads * c, bias=false; init),
+        v = Dense(n_dims_s => n_heads * c, bias=false; init),
+    )
+    map_points = (
+        q = Dense(n_dims_s => n_heads * n_query_points * 3, bias=false; init),
+        k = Dense(n_dims_s => n_heads * n_query_points * 3, bias=false; init),
+        v = Dense(n_dims_s => n_heads * n_point_values * 3, bias=false; init),
     )
     map_pairs = Dense(n_dims_z => n_heads, bias=false; init)
     map_final =
@@ -118,30 +122,13 @@ function (ipa::InvariantPointAttention)(
     (; n_heads, c, n_query_points, n_point_values) = ipa
 
     # map inputs (residues come at the last dimension)
-    nodes = reshape(ipa.map_nodes(s), n_heads, :, n_residues)
-    points = transform(rigid, reshape(ipa.map_points(s), 3, :, n_residues))
+    nodes_q = reshape(ipa.map_nodes.q(s), n_heads, c, n_residues)
+    nodes_k = reshape(ipa.map_nodes.k(s), n_heads, c, n_residues)
+    nodes_v = reshape(ipa.map_nodes.v(s), n_heads, c, n_residues)
+    points_q = reshape(transform(rigid, reshape(ipa.map_points.q(s), 3, :, n_residues)), 3, n_heads, n_query_points, n_residues)
+    points_k = reshape(transform(rigid, reshape(ipa.map_points.k(s), 3, :, n_residues)), 3, n_heads, n_query_points, n_residues)
+    points_v = reshape(transform(rigid, reshape(ipa.map_points.v(s), 3, :, n_residues)), 3, n_heads, n_point_values, n_residues)
     bias = ipa.map_pairs(z)
-
-    # split into queries, keys and values
-    # NOTE: workaround to avoid bugs associated with the chunk function
-    #nodes_q, nodes_k, nodes_v = chunk(nodes, size=[c, c, c], dims=2)
-    i = firstindex(nodes, 2)
-    nodes_q = nodes[:,i:i+c-1,:]; i += size(nodes_q, 2)
-    nodes_k = nodes[:,i:i+c-1,:]; i += size(nodes_k, 2)
-    nodes_v = nodes[:,i:i+c-1,:]
-    #points_q, points_k, points_v = chunk(
-    #    points,
-    #    size=n_heads * [n_query_points, n_query_points, n_point_values],
-    #    dims=2,
-    #)
-    i = firstindex(points, 2)
-    points_q = points[:,i:i+n_heads*n_query_points-1,:]; i += size(points_q, 2)
-    points_k = points[:,i:i+n_heads*n_query_points-1,:]; i += size(points_k, 2)
-    points_v = points[:,i:i+n_heads*n_point_values-1,:]
-
-    points_q = reshape(points_q, 3, n_heads, :, n_residues)
-    points_k = reshape(points_k, 3, n_heads, :, n_residues)
-    points_v = reshape(points_v, 3, n_heads, :, n_residues)
 
     # run message passing
     w_C = F(√(2 / 9n_query_points))


### PR DESCRIPTION
This PR decompose the weight used to calculate queries, keys and values (QKVs) into three separated weights, which doesn't change the behavior of this layer but we'll need to customize weight loading to load a pre-trained layer properly to a new one (see below for the code).

The main motivation is because it is recommended by the Muon optimizer:

> A third result is that Muon works better for optimizing transformers if it is applied to their Q, K, V parameters separately, rather than together as would be the default for transformer implementations that parametrize QKV as a single linear layer whose outputs are split.
https://kellerjordan.github.io/posts/muon/

- - -

Here is the custom method to load old weights into the new layer.
```julia
using MessagePassingIPA: InvariantPointAttention
using Flux: Flux

# Load this method before loading an old weights file.
function Flux.loadmodel!(dst::InvariantPointAttention, src; filter, cache)
    (; n_heads, c, n_query_points, n_point_values) = dst

    weight_qkv = reshape(src.map_nodes.weight, n_heads, c, 3, :)  # the last dimension is n_dims_s
    vec(dst.map_nodes.q.weight) .= vec(weight_qkv[:, :, 1, :])
    vec(dst.map_nodes.k.weight) .= vec(weight_qkv[:, :, 2, :])
    vec(dst.map_nodes.v.weight) .= vec(weight_qkv[:, :, 3, :])

    weight_qkv = reshape(src.map_points.weight, 3, n_heads, 2n_query_points + n_point_values, :)  # the last dimension is n_dims_s
    vec(dst.map_points.q.weight) .= vec(weight_qkv[:, :,                   1: n_query_points, :])
    vec(dst.map_points.k.weight) .= vec(weight_qkv[:, :,  n_query_points + 1:2n_query_points, :])
    vec(dst.map_points.v.weight) .= vec(weight_qkv[:, :, 2n_query_points + 1:end            , :])

    Flux.loadmodel!(dst.map_pairs, src.map_pairs)
    Flux.loadmodel!(dst.map_final, src.map_final)
    Flux.loadmodel!(dst.header_weights_raw, src.header_weights_raw)

    dst
end
```

The following is a suite of test files I used to verify the loading functions.

model.jl
```julia
using MessagePassingIPA: InvariantPointAttention
using Flux

# dummy model
struct Model
    iptastack
end

Flux.@layer Model

function Model(d_s, d_z)
    ipastack = map(1:3) do _
        (
            ipa_norm = LayerNorm(d_s),
            ipa = InvariantPointAttention(d_s, d_z),
            ff_norm = LayerNorm(d_s),
            ff = Chain(Dense(d_s => d_s, swish), Dense(d_s => d_s, swish), Dense(d_s => d_s)),
        )
    end
    return Model(ipastack)
end

function (m::Model)(g, f, s, z)
    for l in m.iptastack
        s += l.ipa(g, l.ipa_norm(s), z, f)
        s += l.ff(l.ff_norm(s))
    end
    s
end
```

saveweights.jl
```julia
using GraphNeuralNetworks
using MessagePassingIPA: RigidTransformation, rigid_from_3points
using JLD2: jldsave
using DelimitedFiles: writedlm
using Random

include("model.jl")

d_s = 32
d_z = 16
model = Model(d_s, d_z)
jldsave("weights.jld2", state = Flux.state(model))

rng = Xoshiro(1234)
n = 100
X = randn(rng, Float32, 3, 3, n)
f = RigidTransformation(rigid_from_3points(X[:, 1, :], X[:, 2, :], X[:, 3, :])...)
g = knn_graph(X[:, 1, :], 8)
s = randn(rng, Float32, d_s, n)
z = randn(rng, Float32, d_z, g.num_edges)
writedlm("output.txt", model(g, f, s, z))
```

loadweights.jl
```julia
using MessagePassingIPA: RigidTransformation, rigid_from_3points
using GraphNeuralNetworks
using JLD2
using DelimitedFiles: readdlm
using Random

include("model.jl")
d_s = 32
d_z = 16
model = Model(d_s, d_z)
state = JLD2.load("weights.jld2")["state"]
Flux.loadmodel!(model, state)

rng = Xoshiro(1234)
n = 100
X = randn(rng, Float32, 3, 3, n)
f = RigidTransformation(rigid_from_3points(X[:, 1, :], X[:, 2, :], X[:, 3, :])...)
g = knn_graph(X[:, 1, :], 8)
s = randn(rng, Float32, d_s, n)
z = randn(rng, Float32, d_z, g.num_edges)
@assert model(g, f, s, z) ≈ readdlm("output.txt", Float32)
```